### PR TITLE
fix: harden CI/release pipeline and enable GitHub Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,36 +6,41 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Build and Test
     runs-on: macos-14
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@1242409711ff5721add51979e9e11e23ebb7e5a4 # v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '16.2'
 
       - name: Generate OAuthSecrets.swift
         env:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
         run: |
-          cat > IMAPBackup/Resources/OAuthSecrets.swift <<EOF
-          import Foundation
-          enum OAuthSecrets {
-              static let googleClientId = "$GOOGLE_CLIENT_ID"
-              static let googleClientSecret = "$GOOGLE_CLIENT_SECRET"
-          }
-          EOF
+          printf 'import Foundation\nenum OAuthSecrets {\n    static let googleClientId = "%s"\n    static let googleClientSecret = "%s"\n}\n' \
+            "$GOOGLE_CLIENT_ID" "$GOOGLE_CLIENT_SECRET" \
+            > IMAPBackup/Resources/OAuthSecrets.swift
 
       - name: Build
         run: |
-          xcodebuild -scheme IMAPBackup \
+          xcodebuild -project IMAPBackup.xcodeproj \
+            -scheme IMAPBackup \
             -configuration Debug \
             -destination 'platform=macOS' \
             CODE_SIGN_IDENTITY="-" \
@@ -45,9 +50,11 @@ jobs:
 
       - name: Run tests
         run: |
-          xcodebuild test -scheme IMAPBackup \
+          set -o pipefail
+          xcodebuild test \
+            -project IMAPBackup.xcodeproj \
+            -scheme IMAPBackup \
             -destination 'platform=macOS' \
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
-            | xcpretty --color || true
+            CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,40 +12,59 @@ on:
         required: true
         default: '1.0.0'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build and Create DMG
     runs-on: macos-14
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@1242409711ff5721add51979e9e11e23ebb7e5a4 # v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '16.2'
 
       - name: Set version from tag or input
         id: version
+        env:
+          VERSION_INPUT: ${{ github.event.inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+            VERSION="$VERSION_INPUT"
+            if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+              echo "Invalid version format: $VERSION (expected x.y.z)"
+              exit 1
+            fi
           else
             VERSION="${GITHUB_REF#refs/tags/v}"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Building version: $VERSION"
 
+      - name: Generate OAuthSecrets.swift
+        env:
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+        run: |
+          printf 'import Foundation\nenum OAuthSecrets {\n    static let googleClientId = "%s"\n    static let googleClientSecret = "%s"\n}\n' \
+            "$GOOGLE_CLIENT_ID" "$GOOGLE_CLIENT_SECRET" \
+            > IMAPBackup/Resources/OAuthSecrets.swift
+
       - name: Update version in project
         run: |
-          # Update marketing version in Info.plist
-          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${{ steps.version.outputs.version }}" IMAPBackup/Resources/Info.plist || true
-          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${{ github.run_number }}" IMAPBackup/Resources/Info.plist || true
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${{ steps.version.outputs.version }}" IMAPBackup/Resources/Info.plist
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${{ github.run_number }}" IMAPBackup/Resources/Info.plist
 
       - name: Build application
         run: |
-          xcodebuild -scheme IMAPBackup \
+          xcodebuild -project IMAPBackup.xcodeproj \
+            -scheme IMAPBackup \
             -configuration Release \
             -derivedDataPath build \
             -destination 'platform=macOS' \
@@ -61,43 +80,53 @@ jobs:
 
       - name: Create DMG
         run: |
-          # Create a temporary directory for DMG contents
           mkdir -p dmg-contents
           cp -R dist/IMAPBackup.app dmg-contents/
-
-          # Create a symbolic link to Applications folder
           ln -s /Applications dmg-contents/Applications
-
-          # Create the DMG
           hdiutil create -volname "IMAP Backup" \
             -srcfolder dmg-contents \
             -ov -format UDZO \
             "IMAPBackup-${{ steps.version.outputs.version }}.dmg"
-
-          # Clean up
           rm -rf dmg-contents
 
       - name: Upload DMG artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: IMAPBackup-${{ steps.version.outputs.version }}
           path: IMAPBackup-${{ steps.version.outputs.version }}.dmg
           retention-days: 90
 
+      - name: Create tag for manual dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
+
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77 # v1
         with:
           files: IMAPBackup-${{ steps.version.outputs.version }}.dmg
           generate_release_notes: true
           draft: false
           prerelease: false
+          body: |
+            ## Installation
+
+            Download `IMAPBackup-${{ steps.version.outputs.version }}.dmg`, open it, and drag **IMAPBackup** to your Applications folder.
+
+            > **First launch on macOS:** macOS will block the app because it is not notarized. Right-click the app and choose **Open**, then click **Open** in the dialog. Alternatively, run:
+            > ```
+            > xattr -dr com.apple.quarantine /Applications/IMAPBackup.app
+            > ```
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload to manual release
+      - name: Create Release (manual dispatch)
         if: github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77 # v1
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: Release v${{ steps.version.outputs.version }}
@@ -105,5 +134,14 @@ jobs:
           generate_release_notes: true
           draft: false
           prerelease: false
+          body: |
+            ## Installation
+
+            Download `IMAPBackup-${{ steps.version.outputs.version }}.dmg`, open it, and drag **IMAPBackup** to your Applications folder.
+
+            > **First launch on macOS:** macOS will block the app because it is not notarized. Right-click the app and choose **Open**, then click **Open** in the dialog. Alternatively, run:
+            > ```
+            > xattr -dr com.apple.quarantine /Applications/IMAPBackup.app
+            > ```
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/IMAPBackup/Models/BackupState.swift
+++ b/IMAPBackup/Models/BackupState.swift
@@ -57,7 +57,7 @@ enum BackupStatus: String, Codable {
     case connecting = "Connecting..."
     case fetchingFolders = "Fetching folders..."
     case counting = "Counting emails..."
-    case scanning = "Scanning folder..."
+    case scanning = "Scanning emails..."
     case downloading = "Downloading..."
     case completed = "Completed"
     case failed = "Failed"

--- a/IMAPBackup/Services/SearchService.swift
+++ b/IMAPBackup/Services/SearchService.swift
@@ -639,7 +639,9 @@ actor SearchService {
     }
 
     private func extractPathInfo(from url: URL) -> (accountId: String, mailbox: String) {
-        let relativePath = url.path.replacingOccurrences(of: backupLocation.path + "/", with: "")
+        let resolvedBase = backupLocation.resolvingSymlinksInPath().path
+        let resolvedPath = url.resolvingSymlinksInPath().path
+        let relativePath = resolvedPath.replacingOccurrences(of: resolvedBase + "/", with: "")
         let components = relativePath.components(separatedBy: "/")
 
         guard components.count >= 2 else {


### PR DESCRIPTION
## Summary

- Fixes CI silently masking test failures (xcpretty pipe removed)
- Adds missing `OAuthSecrets.swift` generation to release workflow (every release was failing to compile)
- Fixes shell injection vulnerability in version input handling
- Pins all third-party actions to immutable commit SHAs
- Adds `permissions`, `concurrency`, and `timeout-minutes` to both workflows
- Pins Xcode to 16.2 for reproducible builds
- Produces a signed-free `.dmg` with Gatekeeper bypass instructions in release notes

## Test plan

- [ ] CI run on this PR passes (green badge)
- [ ] Trigger `workflow_dispatch` with version `0.3.0` to validate end-to-end `.dmg` release

🤖 Generated with [Claude Code](https://claude.com/claude-code)