### PR TITLE
fix: prevent non-UTF-8 bytes from hanging IDLE and corrupting binary email bodies (C2, C3)

### DIFF
--- a/IMAPBackup/Services/IMAPService.swift
+++ b/IMAPBackup/Services/IMAPService.swift
@@ -610,61 +610,85 @@ actor IMAPService {
         // Read response and stream to file
         var totalBytesWritten: Int64 = 0
         var headerBuffer = ""
-        var foundLiteralSize = false
         var literalSize: Int = 0
         var literalBytesReceived: Int = 0
         var isComplete = false
 
+        // Phase 1: String-based header scan to locate {size}\r\n.
+        // IMAP headers and status lines are ASCII, so readResponse() is safe here.
+        // readResponse() now falls back to .isoLatin1 so non-ASCII server text won't
+        // stall the loop by returning "".
         while !isComplete {
             let chunk = try await readResponse()
+            headerBuffer += chunk
 
-            if !foundLiteralSize {
-                // Still looking for the literal size in the header
-                headerBuffer += chunk
+            if let braceStart = headerBuffer.range(of: "{"),
+               let braceEnd = headerBuffer.range(of: "}", range: braceStart.upperBound..<headerBuffer.endIndex) {
 
-                // Look for {size} pattern
-                if let braceStart = headerBuffer.range(of: "{"),
-                   let braceEnd = headerBuffer.range(of: "}", range: braceStart.upperBound..<headerBuffer.endIndex) {
+                let sizeString = String(headerBuffer[braceStart.upperBound..<braceEnd.lowerBound])
+                if let size = Int(sizeString) {
+                    literalSize = size
+                    logDebug("Streaming email UID \(uid): \(size) bytes")
 
-                    let sizeString = String(headerBuffer[braceStart.upperBound..<braceEnd.lowerBound])
-                    if let size = Int(sizeString) {
-                        literalSize = size
-                        foundLiteralSize = true
-                        logDebug("Streaming email UID \(uid): \(size) bytes")
-
-                        // Find where the actual data starts (after }\r\n)
-                        if let dataStart = headerBuffer.range(of: "}\r\n")?.upperBound {
-                            let remainingData = String(headerBuffer[dataStart...])
-                            if let data = remainingData.data(using: .utf8) ?? remainingData.data(using: .ascii) {
-                                let bytesToWrite = min(data.count, literalSize)
-                                if bytesToWrite > 0 {
-                                    try fileHandle.write(contentsOf: data.prefix(bytesToWrite))
-                                    literalBytesReceived += bytesToWrite
-                                    totalBytesWritten += Int64(bytesToWrite)
-                                }
+                    // Write any body bytes that arrived in the same chunk as the header.
+                    // Use .isoLatin1 (bijective for all 256 byte values) so binary bytes
+                    // in the pre-body overshoot are preserved exactly (C3).
+                    if let dataStart = headerBuffer.range(of: "}\r\n")?.upperBound {
+                        let remainingStr = String(headerBuffer[dataStart...])
+                        if let data = remainingStr.data(using: .isoLatin1) {
+                            let bytesToWrite = min(data.count, literalSize)
+                            if bytesToWrite > 0 {
+                                try fileHandle.write(contentsOf: data.prefix(bytesToWrite))
+                                literalBytesReceived += bytesToWrite
+                                totalBytesWritten += Int64(bytesToWrite)
                             }
                         }
                     }
+                    break  // Found literal size — switch to raw Data phase
                 }
-            } else {
-                // Streaming mode - write data directly to file
-                let bytesRemaining = literalSize - literalBytesReceived
+            }
 
-                if bytesRemaining > 0 {
-                    if let data = chunk.data(using: .utf8) ?? chunk.data(using: .ascii) {
-                        let bytesToWrite = min(data.count, bytesRemaining)
-                        if bytesToWrite > 0 {
-                            try fileHandle.write(contentsOf: data.prefix(bytesToWrite))
-                            literalBytesReceived += bytesToWrite
-                            totalBytesWritten += Int64(bytesToWrite)
-                        }
+            // Tagged response may arrive in the same chunk as the header (e.g. empty body)
+            if chunk.contains("\(tag) OK") || chunk.contains("\(tag) NO") || chunk.contains("\(tag) BAD") {
+                isComplete = true
+            }
+        }
+
+        // Phase 2: Raw Data receive loop — reads bytes directly from NWConnection without
+        // any String conversion, so binary email content is written to disk intact (C3).
+        while !isComplete {
+            let rawData: Data = try await withCheckedThrowingContinuation { continuation in
+                connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { data, _, _, error in
+                    if let error = error {
+                        continuation.resume(throwing: IMAPError.receiveFailed(error.localizedDescription))
+                    } else if let data = data, !data.isEmpty {
+                        continuation.resume(returning: data)
+                    } else {
+                        continuation.resume(throwing: IMAPError.receiveFailed("No data received"))
                     }
                 }
             }
 
-            // Check for completion
-            if chunk.contains("\(tag) OK") || chunk.contains("\(tag) NO") || chunk.contains("\(tag) BAD") {
-                isComplete = true
+            // Write body bytes up to the declared literal size
+            let bytesRemaining = literalSize - literalBytesReceived
+            if bytesRemaining > 0 {
+                let bytesToWrite = min(rawData.count, bytesRemaining)
+                if bytesToWrite > 0 {
+                    try fileHandle.write(contentsOf: rawData.prefix(bytesToWrite))
+                    literalBytesReceived += bytesToWrite
+                    totalBytesWritten += Int64(bytesToWrite)
+                }
+            }
+
+            // Check for the IMAP tagged response after all body bytes are received.
+            // The tagged response is ASCII; searching raw bytes for the tag is safe.
+            if literalBytesReceived >= literalSize {
+                let tagBytes = Data(tag.utf8)
+                if rawData.range(of: tagBytes + Data(" OK".utf8)) != nil ||
+                   rawData.range(of: tagBytes + Data(" NO".utf8)) != nil ||
+                   rawData.range(of: tagBytes + Data(" BAD".utf8)) != nil {
+                    isComplete = true
+                }
             }
         }
 
@@ -809,7 +833,14 @@ actor IMAPService {
                     return
                 }
 
-                if let data = data, let response = String(data: data, encoding: .utf8) {
+                if let data = data, !data.isEmpty {
+                    // Attempt UTF-8 first; fall back to ISO Latin-1 which is bijective over
+                    // all 256 byte values and never fails. This prevents non-UTF-8 bytes
+                    // (binary attachments, non-UTF-8 server error text) from returning ""
+                    // and causing while-true read loops to spin forever (C2).
+                    let response = String(data: data, encoding: .utf8)
+                        ?? String(data: data, encoding: .isoLatin1)
+                        ?? ""
                     trace("readResponse: got \(data.count) bytes")
                     continuation.resume(returning: response)
                 } else {

--- a/IMAPBackupTests/BinaryEncodingTests.swift
+++ b/IMAPBackupTests/BinaryEncodingTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import IMAPBackup
+
+/// Tests for the binary-data-safety fixes (C2 + C3).
+///
+/// `readResponse()` and `performStreamingFetch()` are private methods on
+/// `IMAPService` that operate on a live `NWConnection`, so end-to-end unit
+/// testing requires a real IMAP server (see IntegrationTests/).
+///
+/// These tests validate the encoding invariants that the fixes depend on,
+/// and serve as executable documentation of those invariants.
+final class BinaryEncodingTests: XCTestCase {
+
+    // MARK: - C2: readResponse() non-UTF-8 fallback (tasks 1.3 / 1.4)
+
+    /// The fix: `String(data:encoding:.utf8) ?? String(data:encoding:.isoLatin1)`.
+    /// This test confirms that isoLatin1 never returns nil for any byte value,
+    /// so readResponse() can never produce "" due to an encoding failure.
+    func testISOLatin1NeverFailsForAnyByte() {
+        // Full 256-byte range including 0x80–0xFF which are invalid UTF-8
+        let allBytes = Data(0x00...0xFF)
+        let result = String(data: allBytes, encoding: .isoLatin1)
+        XCTAssertNotNil(result, "ISO Latin-1 must decode any byte sequence")
+        XCTAssertFalse(result?.isEmpty ?? true, "ISO Latin-1 result must not be empty")
+    }
+
+    /// Confirms that a byte sequence containing 0x80–0xFF fails UTF-8 decoding
+    /// — establishing that the fallback path in readResponse() is reachable.
+    func testNonUTF8BytesFailUTF8Decoding() {
+        let binaryBytes = Data([0x80, 0x90, 0xA0, 0xFF])
+        XCTAssertNil(
+            String(data: binaryBytes, encoding: .utf8),
+            "Bytes 0x80–0xFF must not decode as UTF-8"
+        )
+    }
+
+    /// Confirms that mixed non-UTF-8 + ASCII bytes still produce a string
+    /// containing the ASCII portion when decoded via isoLatin1 — matching
+    /// the C2 requirement that a tagged response like "A0001 OK" survives
+    /// arrival in a chunk that also contains binary attachment bytes.
+    func testMixedBinaryAndASCIIPreservesASCIIPortion() {
+        // Simulate: binary attachment bytes followed by IMAP tagged response
+        var mixed = Data([0x80, 0x9F, 0xC3, 0xFE])   // invalid UTF-8
+        mixed.append(Data("A0001 OK\r\n".utf8))
+
+        let utf8Result = String(data: mixed, encoding: .utf8)
+        XCTAssertNil(utf8Result, "Mixed chunk should fail UTF-8")
+
+        let isoResult = String(data: mixed, encoding: .isoLatin1)
+        XCTAssertNotNil(isoResult, "isoLatin1 must succeed for mixed bytes")
+        XCTAssertTrue(
+            isoResult?.contains("A0001 OK") ?? false,
+            "ASCII tagged response must be preserved in isoLatin1-decoded string"
+        )
+    }
+
+    // MARK: - C3: performStreamingFetch binary round-trip (tasks 3.1 / 3.2 / 3.3)
+
+    /// The fix relies on .isoLatin1 being a perfect bijection: every byte
+    /// encodes to a unique code point and decodes back to the same byte.
+    /// This is the invariant that makes the header→body transition safe.
+    func testISOLatin1RoundTripPreservesAllBytes() {
+        let original = Data(0x00...0xFF)
+        guard let encoded = String(data: original, encoding: .isoLatin1),
+              let roundTripped = encoded.data(using: .isoLatin1) else {
+            XCTFail("isoLatin1 round-trip must not fail for any byte value")
+            return
+        }
+        XCTAssertEqual(
+            original, roundTripped,
+            "isoLatin1 round-trip must preserve every byte value 0x00–0xFF"
+        )
+    }
+
+    /// Confirms that a raw Data chunk containing the IMAP tag pattern can be
+    /// detected by searching for the ASCII bytes directly in Data — the
+    /// mechanism used in Phase 2 of the fixed performStreamingFetch.
+    func testTaggedResponseDetectedInRawData() {
+        let tag = "A0001"
+        var chunk = Data([0xDE, 0xAD, 0xBE, 0xEF])   // trailing binary body bytes
+        chunk.append(Data(")\r\n\(tag) OK FETCH completed\r\n".utf8))
+
+        let tagBytes = Data(tag.utf8)
+        let okBytes = Data(" OK".utf8)
+        XCTAssertNotNil(
+            chunk.range(of: tagBytes + okBytes),
+            "IMAP tagged response must be detectable by raw byte search in Data"
+        )
+    }
+
+    /// ASCII email bodies must be unaffected by the fix: bytes that are valid
+    /// UTF-8 decode identically under both UTF-8 and isoLatin1 (0x00–0x7F).
+    func testASCIIEmailBodyRoundTripUnchanged() {
+        let asciiBody = "From: sender@example.com\r\nSubject: Hello\r\n\r\nPlain text body.\r\n"
+        let original = Data(asciiBody.utf8)
+
+        guard let isoStr = String(data: original, encoding: .isoLatin1),
+              let roundTripped = isoStr.data(using: .isoLatin1) else {
+            XCTFail("ASCII data must round-trip through isoLatin1 without error")
+            return
+        }
+        XCTAssertEqual(original, roundTripped, "ASCII email bytes must be identical after isoLatin1 round-trip")
+    }
+}


### PR DESCRIPTION
## Summary

- **C2**: `readResponse()` now falls back to `.isoLatin1` on UTF-8 decode failure. Previously it returned `""`, which caused any `while true` read loop (including IDLE) to spin forever on binary attachment data or non-UTF-8 server error text.
- **C3**: `performStreamingFetch` replaced its String-based body-write loop with a two-phase approach: ASCII header scan stays String-based, body bytes are written as raw `Data` via `NWConnection.receive` directly. Binary email bodies (attachments) are now preserved byte-for-byte instead of being silently corrupted.
- Adds `BinaryEncodingTests` validating the isoLatin1 bijection invariant and tagged-response detection in raw `Data`.

## Test plan

- [x] Full test suite passes locally (188 tests)
- [ ] Manually back up an account with binary attachments; confirm `.eml` files open correctly in Mail.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)